### PR TITLE
Move formatting of page count out of JavaScript

### DIFF
--- a/resources/htmlSlides.js
+++ b/resources/htmlSlides.js
@@ -25,7 +25,7 @@
         });
 
         //Set total slide count in header
-        $('#slide-total').html('/' + slideCount);
+        $('#slide-total').html(slideCount);
         
         //Check for hash and validate value    
         if (slideHash && (parseInt((slideHash.substring(1)), 10) <= slideCount)) {

--- a/slideshow.html
+++ b/slideshow.html
@@ -12,7 +12,7 @@
     <nav>
         <ul>
             <li><button id="prev-btn" title="Previous slide">Previous Slide</button></li>
-            <li><span id="slide-number"></span><span id="slide-total"></span></li>
+            <li><span id="slide-number"></span>/<span id="slide-total"></span></li>
             <li><button id="next-btn" title="Next Slide">Next Slide</button></li>
         </ul>
     </nav>


### PR DESCRIPTION
I suggest putting "/" in the HTML instead of the $('#slide-total') variable, making it possible to modify its presentation, e.g. changing "1/10" to "1 of 10", "1 (10)", etc.
