### PR TITLE
Fixed: adding of "slide" class to section elements removed other section classes

### DIFF
--- a/lib/htmlSlides.js
+++ b/lib/htmlSlides.js
@@ -35,7 +35,7 @@ var htmlSlides = {
     $('#deck > section').each(function(index, el) {
       $el = $(el);
       $el.attr('id', 'slide' + (index +1));
-      $el.attr('class', 'slide');     
+      $el.attr('class', ($el.attr('class') + ' slide ') );     
     });
 
     //Set total slide count in header

--- a/lib/htmlSlides.js
+++ b/lib/htmlSlides.js
@@ -35,7 +35,7 @@ var htmlSlides = {
     $('#deck > section').each(function(index, el) {
       $el = $(el);
       $el.attr('id', 'slide' + (index +1));
-      $el.attr('class', ($el.attr('class') + ' slide ') );     
+      $el.addClass('slide');     
     });
 
     //Set total slide count in header


### PR DESCRIPTION
> Nice catch. How about we do this instead?
> 
> ```
> $el.addClass('slide');
> ```

https://github.com/robflaherty/html-slideshow/pull/4
